### PR TITLE
feat: change containericons in header to button 'sair'

### DIFF
--- a/src/components/containers/ContainerHeaderFooterResponsive/ContainerHeaderFooterResponsive.spec.tsx
+++ b/src/components/containers/ContainerHeaderFooterResponsive/ContainerHeaderFooterResponsive.spec.tsx
@@ -16,17 +16,17 @@ describe('ContainerHeaderFooterResponsive Component', () => {
     const logo = screen.getByRole('img', { name: 'logo Routinely' });
     expect(logo).toBeInTheDocument();
 
-    const iconNotification = screen.getByAltText('notificações');
-    expect(iconNotification).toBeInTheDocument();
-
     const iconMenu = screen.getByAltText('abrir menu');
     expect(iconMenu).toBeInTheDocument();
 
     const title = screen.getByRole('heading', { name: 'jest test' });
     expect(title).toBeInTheDocument();
 
-    const button = screen.getByRole('button');
-    expect(button).toBeInTheDocument();
+    const buttonBack = screen.getByRole('button', { name: /Voltar/i });
+    expect(buttonBack).toBeInTheDocument();
+
+    const buttonExit = screen.getByRole('button', { name: /Sair/i });
+    expect(buttonExit).toBeInTheDocument();
   });
 
   it('should render without session', () => {

--- a/src/components/containers/DashboardContainer/DashboardContainer.spec.tsx
+++ b/src/components/containers/DashboardContainer/DashboardContainer.spec.tsx
@@ -98,7 +98,7 @@ describe('<DashboardContainer/>', () => {
 
     await DashboardContainerMock();
 
-    const iconNotification = screen.getByAltText('notificações');
+    const iconNotification = screen.getByRole('button', { name: 'Sair' });
     expect(iconNotification).toBeInTheDocument();
 
     const iconMenu = screen.getByAltText('abrir menu');

--- a/src/components/containers/PasswordsPagesContainer/PasswordsPagesContainer.spec.tsx
+++ b/src/components/containers/PasswordsPagesContainer/PasswordsPagesContainer.spec.tsx
@@ -22,11 +22,13 @@ describe('PasswordsPagesContainer Component', () => {
   it('Should render', () => {
     render(<PasswordsPagesContainer {...mockProps} />);
 
-    const buttonHeader = screen.getByRole('button');
-    expect(buttonHeader).toBeInTheDocument();
-    expect(buttonHeader).toHaveTextContent('Voltar');
+    const [buttonHeaderBack, buttonHeaderExit] = screen.getAllByRole('button');
+    expect(buttonHeaderBack).toBeInTheDocument();
+    expect(buttonHeaderBack).toHaveTextContent('Voltar');
+    expect(buttonHeaderExit).toBeInTheDocument();
+    expect(buttonHeaderExit).toHaveTextContent('Sair');
 
-    const iconBack = buttonHeader.querySelector('img[alt="Voltar"]');
+    const iconBack = buttonHeaderBack.querySelector('img[alt="Voltar"]');
     expect(iconBack).toBeInTheDocument();
 
     const logo = screen.getByRole('img', { name: 'logo Routinely' });

--- a/src/components/headers/MenuHeader/Menu.spec.tsx
+++ b/src/components/headers/MenuHeader/Menu.spec.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import MenuHeader from '.';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { IMenuItem } from '.';
+import MenuHeader from '.';
 
 const mockMenuItems: IMenuItem[] = [
   { name: 'Home', id: 1, url: '/' },
@@ -13,7 +13,6 @@ describe('MenuHeader', () => {
   it('renders notification and icons', () => {
     render(<MenuHeader menuItems={mockMenuItems} />);
 
-    expect(screen.getByAltText('notificações')).toBeInTheDocument();
     expect(screen.getByAltText('abrir menu')).toBeInTheDocument();
   });
 

--- a/src/components/headers/MenuHeader/index.tsx
+++ b/src/components/headers/MenuHeader/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import bellNotificationIcon from '@public/icons/bellNotification.svg';
 import closeMenuIcon from '@public/icons/closeMenuHeader.svg';
 import hamburguerIcon from '@public/icons/hamburguer.svg';
 import Image from 'next/image';
@@ -24,8 +23,8 @@ export default function MenuHeader({ menuItems }: IMenuHeader) {
 
   return (
     <S.Container>
+      <S.ExitButton>Sair</S.ExitButton>
       <S.ContainerIcons>
-        <Image src={bellNotificationIcon} alt="notificações" role="icon" />
         <Image
           src={hamburguerIcon}
           alt="abrir menu"

--- a/src/components/headers/MenuHeader/styles.tsx
+++ b/src/components/headers/MenuHeader/styles.tsx
@@ -13,11 +13,15 @@ export const Container = styled.div`
 `;
 
 export const ContainerIcons = styled.div`
-  display: flex;
+  display: none;
   gap: 8px;
+  ${media.mobile} {
+    display: flex;
+  }
 `;
 
 export const Wrapper = styled.div`
+  display: none;
   position: absolute;
   top: 40px;
   left: -104px;
@@ -33,6 +37,7 @@ export const Wrapper = styled.div`
   }
 
   ${media.mobile} {
+    display: block;
     top: 152%;
   }
 `;
@@ -66,5 +71,17 @@ export const Item = styled.li`
 
   > p {
     margin: 0;
+  }
+`;
+
+export const ExitButton = styled.button`
+  background-color: transparent;
+  border: none;
+  color: ${colors.white};
+  cursor: pointer;
+  font-weight: bold;
+
+  ${media.mobile} {
+    display: none;
   }
 `;

--- a/src/components/headers/Primary/Primary.spec.tsx
+++ b/src/components/headers/Primary/Primary.spec.tsx
@@ -19,11 +19,13 @@ describe('PrimaryHeader', () => {
   //O texto "Notificações vem do componente de imagem do "MenuHeader". Caso o alt desse componente alterar, o teste irá apresentar erro
   it('should render MenuHeader Component hasUser if true', () => {
     render(<PrimaryHeader menuItems={menuItems} hasUser={true} />);
-    expect(screen.getByAltText('notificações')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sair' })).toBeInTheDocument();
+    expect(screen.getByAltText('abrir menu')).toBeInTheDocument();
   });
   //O texto "Notificações vem do componente de imagem do "MenuHeader". Caso o alt desse componente alterar, o teste irá apresentar erro
   it('should not render MenuHeader Component hasUser if false', () => {
     render(<PrimaryHeader menuItems={menuItems} hasUser={false} />);
-    expect(screen.queryByAltText('notificações')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sair' })).not.toBeInTheDocument();
+    expect(screen.queryByAltText('abrir menu')).not.toBeInTheDocument();
   });
 });

--- a/src/components/headers/Secondary/Secondary.spec.tsx
+++ b/src/components/headers/Secondary/Secondary.spec.tsx
@@ -22,11 +22,13 @@ describe('SecondaryHeader', () => {
   //O texto "Notificações vem do componente de imagem do "MenuHeader". Caso o alt desse componente alterar, o teste irá apresentar erro
   it('should render MenuHeader Component hasUser if true', () => {
     render(<SecondaryHeader hrefBackPage="/back" menuItems={menuItems} hasUser={true} />);
-    expect(screen.getByAltText('notificações')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sair' })).toBeInTheDocument();
+    expect(screen.getByAltText('abrir menu')).toBeInTheDocument();
   });
   //O texto "Notificações vem do componente de imagem do "MenuHeader". Caso o alt desse componente alterar, o teste irá apresentar erro
   it('should not render MenuHeader Component hasUser if false', () => {
     render(<SecondaryHeader hrefBackPage="/back" menuItems={menuItems} hasUser={false} />);
-    expect(screen.queryByAltText('notificações')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sair' })).not.toBeInTheDocument();
+    expect(screen.queryByAltText('abrir menu')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
adaptando o header para o novo layout